### PR TITLE
Add local storage resume support

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 </head>
 <body>
 <h1>ELADEB-R Auto-évaluation</h1>
+<button id="reset-btn">Réinitialiser l'évaluation</button>
 <div id="step-container"></div>
 <script>
 const domains = [
@@ -31,6 +32,7 @@ const data = {
 };
 let currentStep = 0;
 const container = document.getElementById('step-container');
+const STORAGE_KEY = 'eladeb-eval';
 
 function nextStep() {
     currentStep++;
@@ -204,6 +206,7 @@ function renderPriority() {
     container.appendChild(div);
     document.getElementById('next').onclick = () => {
         data.priority = document.getElementById('priority').value;
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
         nextStep();
     };
 }
@@ -238,6 +241,23 @@ function renderResults() {
     });
     div.appendChild(canvas);
     container.appendChild(div);
+}
+
+function resetEvaluation() {
+    localStorage.removeItem(STORAGE_KEY);
+    location.reload();
+}
+
+document.getElementById('reset-btn').onclick = resetEvaluation;
+
+const saved = localStorage.getItem(STORAGE_KEY);
+if (saved) {
+    if (confirm('Reprendre l\'évaluation sauvegardée ?')) {
+        Object.assign(data, JSON.parse(saved));
+        currentStep = 7;
+    } else {
+        localStorage.removeItem(STORAGE_KEY);
+    }
 }
 
 render();


### PR DESCRIPTION
## Summary
- add a reset evaluation button
- persist evaluation data to `localStorage`
- reload saved results when present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840abde53cc8333acf7852e01f2308e