### PR TITLE
Ajouter des icônes colorées pour la sélection de difficultés

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
         .chart-bar { background: #4CAF50; height: 20px; margin: 2px 0; }
         .chart-bar.need { background: #2196F3; }
         .icon { margin-right: 8px; }
+        .domain-icon { color: #2196F3; }
+        .option { margin-right: 10px; display: inline-flex; align-items: center; }
+        .problem-icon { color: #f44336; margin-left: 4px; }
+        .no-problem-icon { color: #4CAF50; margin-left: 4px; }
     </style>
 </head>
 <body>

--- a/src/app.js
+++ b/src/app.js
@@ -84,9 +84,9 @@ function renderDifficultyPresence() {
     form.innerHTML = `<h2>Difficultés</h2>`;
     const div = document.createElement('div');
     div.className = 'domain-item';
-    div.innerHTML = `<i class="fa ${d.icon} icon"></i><strong>${d.label}</strong> ` +
-        `<label><input type="radio" name="diff" value="yes"> Problème</label> ` +
-        `<label><input type="radio" name="diff" value="no" checked> Pas de problème</label>`;
+    div.innerHTML = `<i class="fa ${d.icon} icon domain-icon"></i><strong>${d.label}</strong> ` +
+        `<label class="option"><input type="radio" name="diff" value="yes"> Problème <i class="fa fa-thumbs-down problem-icon"></i></label> ` +
+        `<label class="option"><input type="radio" name="diff" value="no" checked> Pas de problème <i class="fa fa-thumbs-up no-problem-icon"></i></label>`;
     form.appendChild(div);
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';


### PR DESCRIPTION
## Summary
- ajout de styles pour icônes colorées
- utilisation d'icônes de type pouce vert/rouge pour indiquer la présence d'une difficulté

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b19606f483339e9554eab0aa745b