### PR TITLE
Add color-coded buttons for difficulty selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,18 @@
         .option { margin-right: 10px; display: inline-flex; align-items: center; }
         .problem-icon { color: #f44336; margin-left: 4px; }
         .no-problem-icon { color: #4CAF50; margin-left: 4px; }
+        .diff-buttons { margin-top: 15px; }
+        .diff-btn {
+            color: #fff;
+            font-size: 18px;
+            padding: 15px 30px;
+            margin: 0 10px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+        .diff-problem { background-color: #f44336; }
+        .diff-no-problem { background-color: #4CAF50; }
     </style>
 </head>
 <body>

--- a/src/app.js
+++ b/src/app.js
@@ -100,21 +100,27 @@ function renderDifficultyPresence() {
     const form = document.createElement('div');
     form.innerHTML = `<h2>Difficultés</h2>`;
     const div = createDomainCard(d);
-    const opts = document.createElement('div');
-    opts.innerHTML =
-        `<label class="option"><input type="radio" name="diff" value="yes"> Problème <i class="fa fa-thumbs-down problem-icon"></i></label> ` +
-        `<label class="option"><input type="radio" name="diff" value="no" checked> Pas de problème <i class="fa fa-thumbs-up no-problem-icon"></i></label>`;
-    div.appendChild(opts);
-    form.appendChild(div);
-    const btn = document.createElement('button');
-    btn.textContent = 'Suivant';
-    btn.onclick = () => {
-        const val = document.querySelector('input[name=diff]:checked').value;
-        data.difficulties[currentDomain].presence = val === 'yes';
-        if (!data.difficulties[currentDomain].presence) data.difficulties[currentDomain].intensity = 0;
+    const buttons = document.createElement('div');
+    buttons.className = 'diff-buttons';
+    const probBtn = document.createElement('button');
+    probBtn.className = 'diff-btn diff-problem';
+    probBtn.textContent = 'Problème';
+    probBtn.onclick = () => {
+        data.difficulties[currentDomain].presence = true;
         nextDomain();
     };
-    form.appendChild(btn);
+    const noProbBtn = document.createElement('button');
+    noProbBtn.className = 'diff-btn diff-no-problem';
+    noProbBtn.textContent = 'Pas de problème';
+    noProbBtn.onclick = () => {
+        data.difficulties[currentDomain].presence = false;
+        data.difficulties[currentDomain].intensity = 0;
+        nextDomain();
+    };
+    buttons.appendChild(probBtn);
+    buttons.appendChild(noProbBtn);
+    div.appendChild(buttons);
+    form.appendChild(div);
     container.appendChild(form);
 }
 


### PR DESCRIPTION
## Summary
- add large colored buttons to choose difficulty presence
- update JS logic to handle new buttons

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840b68236b88333991e2ea4d313c113