### PR TITLE
Improve accessibility for custom radio inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ function renderInitialQuestion() {
     const div = document.createElement('div');
     div.innerHTML = '<p>Quel est pour vous le problème le plus important actuellement ?</p>' +
         '<textarea id="question" rows="3" cols="60"></textarea><br>' +
-        '<button id="next">Suivant</button>';
+        '<button id="next" aria-label="Suivant">Suivant</button>';
     container.appendChild(div);
     document.getElementById('next').onclick = () => {
         data.initialQuestion = document.getElementById('question').value;
@@ -67,13 +67,20 @@ function renderDifficultyPresence() {
     domains.forEach((d, i) => {
         const div = document.createElement('div');
         div.className = 'domain-item';
+        div.setAttribute('role', 'radiogroup');
         div.innerHTML = `<strong>${d}</strong> ` +
-            `<label><input type="radio" name="diff${i}" value="yes"> Problème</label> ` +
-            `<label><input type="radio" name="diff${i}" value="no" checked> Pas de problème</label>`;
+            `<label><input type="radio" name="diff${i}" value="yes" aria-label="Problème"> Problème</label> ` +
+            `<label><input type="radio" name="diff${i}" value="no" checked aria-label="Pas de problème"> Pas de problème</label>`;
+        const radios = div.querySelectorAll('input[type=radio]');
+        radios.forEach(r => r.setAttribute('aria-checked', r.checked));
+        radios.forEach(r => r.addEventListener('change', () => {
+            radios.forEach(r2 => r2.setAttribute('aria-checked', r2.checked));
+        }));
         form.appendChild(div);
     });
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';
+    btn.setAttribute('aria-label', 'Suivant');
     btn.onclick = () => {
         domains.forEach((d, i) => {
             const val = document.querySelector(`input[name=diff${i}]:checked`).value;
@@ -93,14 +100,21 @@ function renderDifficultyIntensity() {
         if (!data.difficulties[i].presence) return;
         const div = document.createElement('div');
         div.className = 'domain-item';
+        div.setAttribute('role', 'radiogroup');
         div.innerHTML = `<strong>${d}</strong> ` +
-            `<label><input type="radio" name="int${i}" value="1" checked> Peu important</label> ` +
-            `<label><input type="radio" name="int${i}" value="2"> Important</label> ` +
-            `<label><input type="radio" name="int${i}" value="3"> Très important</label>`;
+            `<label><input type="radio" name="int${i}" value="1" checked aria-label="Peu important"> Peu important</label> ` +
+            `<label><input type="radio" name="int${i}" value="2" aria-label="Important"> Important</label> ` +
+            `<label><input type="radio" name="int${i}" value="3" aria-label="Très important"> Très important</label>`;
+        const radios = div.querySelectorAll('input[type=radio]');
+        radios.forEach(r => r.setAttribute('aria-checked', r.checked));
+        radios.forEach(r => r.addEventListener('change', () => {
+            radios.forEach(r2 => r2.setAttribute('aria-checked', r2.checked));
+        }));
         form.appendChild(div);
     });
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';
+    btn.setAttribute('aria-label', 'Suivant');
     btn.onclick = () => {
         domains.forEach((d, i) => {
             if (!data.difficulties[i].presence) return;
@@ -119,13 +133,20 @@ function renderNeedPresence() {
     domains.forEach((d, i) => {
         const div = document.createElement('div');
         div.className = 'domain-item';
+        div.setAttribute('role', 'radiogroup');
         div.innerHTML = `<strong>${d}</strong> ` +
-            `<label><input type="radio" name="need${i}" value="yes"> Besoin</label> ` +
-            `<label><input type="radio" name="need${i}" value="no" checked> Pas besoin</label>`;
+            `<label><input type="radio" name="need${i}" value="yes" aria-label="Besoin"> Besoin</label> ` +
+            `<label><input type="radio" name="need${i}" value="no" checked aria-label="Pas besoin"> Pas besoin</label>`;
+        const radios = div.querySelectorAll('input[type=radio]');
+        radios.forEach(r => r.setAttribute('aria-checked', r.checked));
+        radios.forEach(r => r.addEventListener('change', () => {
+            radios.forEach(r2 => r2.setAttribute('aria-checked', r2.checked));
+        }));
         form.appendChild(div);
     });
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';
+    btn.setAttribute('aria-label', 'Suivant');
     btn.onclick = () => {
         domains.forEach((d, i) => {
             const val = document.querySelector(`input[name=need${i}]:checked`).value;
@@ -145,14 +166,21 @@ function renderNeedUrgency() {
         if (!data.needs[i].presence) return;
         const div = document.createElement('div');
         div.className = 'domain-item';
+        div.setAttribute('role', 'radiogroup');
         div.innerHTML = `<strong>${d}</strong> ` +
-            `<label><input type="radio" name="urg${i}" value="1" checked> Non urgent</label> ` +
-            `<label><input type="radio" name="urg${i}" value="2"> Moyennement urgent</label> ` +
-            `<label><input type="radio" name="urg${i}" value="3"> Urgent</label>`;
+            `<label><input type="radio" name="urg${i}" value="1" checked aria-label="Non urgent"> Non urgent</label> ` +
+            `<label><input type="radio" name="urg${i}" value="2" aria-label="Moyennement urgent"> Moyennement urgent</label> ` +
+            `<label><input type="radio" name="urg${i}" value="3" aria-label="Urgent"> Urgent</label>`;
+        const radios = div.querySelectorAll('input[type=radio]');
+        radios.forEach(r => r.setAttribute('aria-checked', r.checked));
+        radios.forEach(r => r.addEventListener('change', () => {
+            radios.forEach(r2 => r2.setAttribute('aria-checked', r2.checked));
+        }));
         form.appendChild(div);
     });
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';
+    btn.setAttribute('aria-label', 'Suivant');
     btn.onclick = () => {
         domains.forEach((d, i) => {
             if (!data.needs[i].presence) return;
@@ -173,7 +201,7 @@ function renderNeedOrigin() {
         const div = document.createElement('div');
         div.className = 'domain-item';
         div.innerHTML = `<strong>${d}</strong> ` +
-            `<select id="orig${i}">` +
+            `<select id="orig${i}" aria-label="Origine">` +
             `<option value="P">Professionnels</option>` +
             `<option value="F">Famille</option>` +
             `<option value="E">Entourage</option>` +
@@ -183,6 +211,7 @@ function renderNeedOrigin() {
     });
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';
+    btn.setAttribute('aria-label', 'Suivant');
     btn.onclick = () => {
         domains.forEach((d, i) => {
             if (!data.needs[i].presence) return;
@@ -200,7 +229,7 @@ function renderPriority() {
     div.innerHTML = '<h2>Besoin prioritaire</h2>' +
         '<p>Si on ne pouvait faire qu\'une seule chose pour vous, laquelle choisiriez-vous ?</p>' +
         '<textarea id="priority" rows="3" cols="60"></textarea><br>' +
-        '<button id="next">Terminer</button>';
+        '<button id="next" aria-label="Terminer">Terminer</button>';
     container.appendChild(div);
     document.getElementById('next').onclick = () => {
         data.priority = document.getElementById('priority').value;


### PR DESCRIPTION
## Summary
- add aria-labels to interactive buttons and selectors
- mark radio groups with role="radiogroup" and update aria-checked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840abf3db4c8333bc1d8a692a832fe7