### PR TITLE
Add extra support-info field in needs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ const domains = [
 const data = {
     initialQuestion: '',
     difficulties: domains.map(() => ({ presence: false, intensity: 0 })),
-    needs: domains.map(() => ({ presence: false, urgency: 0, origin: '?' })),
+    needs: domains.map(() => ({ presence: false, urgency: 0, origin: '?', detail: '' })),
     priority: ''
 };
 
@@ -199,7 +199,7 @@ function renderNeedPresence() {
     btn.onclick = () => {
         const val = document.querySelector('input[name=need]:checked').value;
         data.needs[currentDomain].presence = val === 'yes';
-        if (!data.needs[currentDomain].presence) { data.needs[currentDomain].urgency = 0; data.needs[currentDomain].origin = '?'; }
+        if (!data.needs[currentDomain].presence) { data.needs[currentDomain].urgency = 0; data.needs[currentDomain].origin = '?'; data.needs[currentDomain].detail = ''; }
         nextDomain();
     };
     form.appendChild(btn);
@@ -255,14 +255,17 @@ function renderNeedOrigin() {
         `<option value="F">Famille</option>` +
         `<option value="E">Entourage</option>` +
         `<option value="?" selected>Non précisé</option>` +
-        `</select>`;
+        `</select> ` +
+        `<input type="text" id="origDetail" placeholder="Nom ou information">`;
     div.appendChild(opts);
     form.appendChild(div);
     const btn = document.createElement('button');
     btn.textContent = 'Suivant';
     btn.onclick = () => {
         const val = document.getElementById('orig').value;
+        const detailVal = document.getElementById('origDetail').value;
         data.needs[currentDomain].origin = val;
+        data.needs[currentDomain].detail = detailVal;
         nextDomain();
     };
     form.appendChild(btn);
@@ -305,7 +308,7 @@ function renderResults() {
     div.appendChild(codeP);
 
     const table = document.createElement('table');
-    const header = '<tr><th>Domaine</th><th>Intensit\xE9 difficult\xE9</th><th>Urgence besoin</th><th>Origine</th></tr>';
+    const header = '<tr><th>Domaine</th><th>Intensit\xE9 difficult\xE9</th><th>Urgence besoin</th><th>Origine</th><th>Nom/Info</th></tr>';
 
     const maxUrg = Math.max(...data.needs.map(n => n.urgency));
 
@@ -313,6 +316,7 @@ function renderResults() {
         const diff = data.difficulties[i].intensity;
         const need = data.needs[i].urgency;
         const orig = data.needs[i].origin;
+        const detail = data.needs[i].detail || '';
         const rowCls = (diff >= 3 || need >= 3) ? ' class="high"' : '';
 
         const diffCls = diff > 0 ? ` class="val-${diff}"` : '';
@@ -321,7 +325,7 @@ function renderResults() {
         if (need === maxUrg && need > 0) needClasses.push('high-urgency');
         const needCls = needClasses.length ? ` class="${needClasses.join(' ')}"` : '';
 
-        return `<tr${rowCls}><td>${d.label}</td><td${diffCls}>${diff}</td><td${needCls}>${need}</td><td>${orig}</td></tr>`;
+        return `<tr${rowCls}><td>${d.label}</td><td${diffCls}>${diff}</td><td${needCls}>${need}</td><td>${orig}</td><td>${detail}</td></tr>`;
     }).join('');
     div.appendChild(table);
 


### PR DESCRIPTION
## Summary
- extend need data structure with a free text detail field
- keep origin detail when no need selected
- capture detail input during need origin step
- display a new `Nom/Info` column on the result table

## Testing
- `node --check src/app.js`
- `python3 -m py_compile plot_axes_scores.py plot_eladeb.py`


------
https://chatgpt.com/codex/tasks/task_e_6840c503b35c8333ba8148663876e5a2