### PR TITLE
Fix back button state transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,14 @@
         .diff-problem { background-color: #f44336; }
         .diff-no-problem { background-color: #4CAF50; }
 
+        #back {
+            background: none;
+            border: none;
+            font-size: 24px;
+            cursor: pointer;
+            margin-bottom: 10px;
+        }
+
         /* Results styling */
         .results h2 { color: #2196F3; margin-top: 30px; }
         .high { background-color: #ffe0e0; }

--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,11 @@ const data = {
 let currentStep = 0;
 let currentDomain = 0;
 let container;
+const historyStack = [];
+
+function recordState() {
+    historyStack.push({ step: currentStep, domain: currentDomain });
+}
 
 function getProgressText() {
     if (currentStep === 1 || currentStep === 3) {
@@ -76,22 +81,43 @@ function createDomainCard(domain, progress) {
 }
 
 function nextStep() {
+    recordState();
+    nextStepNoRecord();
+}
+
+function nextStepNoRecord() {
     currentStep++;
     currentDomain = 0;
     render();
 }
 
 function nextDomain() {
+    recordState();
     currentDomain++;
     if (currentDomain >= domains.length) {
-        nextStep();
+        nextStepNoRecord();
     } else {
         render();
     }
 }
 
+function goBack() {
+    const prev = historyStack.pop();
+    if (!prev) return;
+    currentStep = prev.step;
+    currentDomain = prev.domain;
+    render();
+}
+
 function render() {
     container.innerHTML = '';
+    if (historyStack.length) {
+        const back = document.createElement('button');
+        back.id = 'back';
+        back.innerHTML = '\u2190';
+        back.onclick = goBack;
+        container.appendChild(back);
+    }
     if (currentStep === 0) renderInitialQuestion();
     else if (currentStep === 1) renderDifficultyPresence();
     else if (currentStep === 2) renderDifficultyIntensity();


### PR DESCRIPTION
## Summary
- adjust navigation so the history stack records transitions once
- use helper `nextStepNoRecord` to skip recording when moving from domain loops

## Testing
- `python plot_eladeb.py` *(fails: ModuleNotFoundError)*
- `python plot_axes_scores.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4770ff88333954bade3707d15f5