### PR TITLE
Improve step transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,12 @@
         .diff-problem { background-color: #f44336; }
         .diff-no-problem { background-color: #4CAF50; }
 
+        #step-container {
+            opacity: 1;
+            transition: opacity 0.3s ease;
+        }
+        .fade-out { opacity: 0; }
+
         #back {
             background: none;
             border: none;

--- a/src/app.js
+++ b/src/app.js
@@ -36,6 +36,14 @@ let currentDomain = 0;
 let container;
 const historyStack = [];
 
+function transition(action) {
+    container.classList.add('fade-out');
+    setTimeout(() => {
+        action();
+        container.classList.remove('fade-out');
+    }, 300);
+}
+
 function recordState() {
     historyStack.push({ step: currentStep, domain: currentDomain });
 }
@@ -100,9 +108,11 @@ function nextDomain() {
 function goBack() {
     const prev = historyStack.pop();
     if (!prev) return;
-    currentStep = prev.step;
-    currentDomain = prev.domain;
-    render();
+    transition(() => {
+        currentStep = prev.step;
+        currentDomain = prev.domain;
+        render();
+    });
 }
 
 function render() {
@@ -132,7 +142,7 @@ function renderInitialQuestion() {
     container.appendChild(div);
     document.getElementById('next').onclick = () => {
         data.initialQuestion = document.getElementById('question').value;
-        nextStep();
+        transition(nextStep);
     };
 }
 
@@ -153,7 +163,7 @@ function renderDifficultyPresence() {
     probBtn.onclick = () => {
         data.difficulties[currentDomain].presence = true;
         div.classList.add('chosen-problem');
-        setTimeout(nextDomain, 400);
+        transition(nextDomain);
     };
     const noProbBtn = document.createElement('button');
     noProbBtn.className = 'diff-btn diff-no-problem';
@@ -162,7 +172,7 @@ function renderDifficultyPresence() {
         data.difficulties[currentDomain].presence = false;
         data.difficulties[currentDomain].intensity = 0;
         div.classList.add('chosen-no-problem');
-        setTimeout(nextDomain, 400);
+        transition(nextDomain);
     };
     buttons.appendChild(probBtn);
     buttons.appendChild(noProbBtn);
@@ -195,7 +205,7 @@ function renderDifficultyIntensity() {
     btn.onclick = () => {
         const val = document.querySelector('input[name=int]:checked').value;
         data.difficulties[currentDomain].intensity = parseInt(val, 10);
-        nextDomain();
+        transition(nextDomain);
     };
     form.appendChild(btn);
     container.appendChild(form);
@@ -222,7 +232,7 @@ function renderNeedPresence() {
         const val = document.querySelector('input[name=need]:checked').value;
         data.needs[currentDomain].presence = val === 'yes';
         if (!data.needs[currentDomain].presence) { data.needs[currentDomain].urgency = 0; data.needs[currentDomain].origin = '?'; }
-        nextDomain();
+        transition(nextDomain);
     };
     form.appendChild(btn);
     container.appendChild(form);
@@ -252,7 +262,7 @@ function renderNeedUrgency() {
     btn.onclick = () => {
         const val = document.querySelector('input[name=urg]:checked').value;
         data.needs[currentDomain].urgency = parseInt(val, 10);
-        nextDomain();
+        transition(nextDomain);
     };
     form.appendChild(btn);
     container.appendChild(form);
@@ -285,7 +295,7 @@ function renderNeedOrigin() {
     btn.onclick = () => {
         const val = document.getElementById('orig').value;
         data.needs[currentDomain].origin = val;
-        nextDomain();
+        transition(nextDomain);
     };
     form.appendChild(btn);
     container.appendChild(form);
@@ -300,7 +310,7 @@ function renderPriority() {
     container.appendChild(div);
     document.getElementById('next').onclick = () => {
         data.priority = document.getElementById('priority').value;
-        nextStep();
+        transition(nextStep);
     };
 }
 


### PR DESCRIPTION
## Summary
- fade out container on each step change
- use transition helper for navigating forward/backward
- add CSS for fading effect

## Testing
- `node --check src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_684137ae79d483339c7bd95fd11807b7