### PR TITLE
Fix renderNeedPresence logic

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -275,14 +275,12 @@ function renderNeedPresence() {
     btn.textContent = 'Suivant';
     btn.onclick = () => {
         const val = document.querySelector('input[name=need]:checked').value;
-codex/refactor-renderneedpresence
         const need = data.needs[currentDomain];
         need.presence = val === 'yes';
         if (!need.presence) {
             need.urgency = 0;
             need.origin = '?';
             need.detail = '';
- main
         }
         transition(nextDomain);
     };


### PR DESCRIPTION
## Summary
- remove leftover codex marker lines from `renderNeedPresence`
- ensure handler updates need presence and resets other fields when not requested

## Testing
- `node -c src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6848959c6e348333897caaac5018ced4