### PR TITLE
Fix card flicker between transitions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -49,13 +49,15 @@ function transition(action) {
     const h = container.offsetHeight;
     container.style.minHeight = `${h}px`;
     container.classList.add('fade-out');
-    setTimeout(() => {
+    const onEnd = () => {
+        container.removeEventListener('transitionend', onEnd);
         action();
         container.classList.remove('fade-out');
         requestAnimationFrame(() => {
             container.style.minHeight = '';
         });
-    }, 300);
+    };
+    container.addEventListener('transitionend', onEnd, { once: true });
 }
 
 function recordState() {


### PR DESCRIPTION
## Summary
- remove timeout-based transition
- rely on `transitionend` event so the previous card never flashes back

## Testing
- `node -e "require('./src/app.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68489ca705ec833385490d1a5291025c