### PR TITLE
Add lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Check Python files
+        run: |
+          python -m py_compile plot_axes_scores.py plot_eladeb.py
+
+      - name: Check JavaScript syntax
+        run: |
+          node --check src/app.js
+
+      - name: Validate HTML
+        run: |
+          npx htmlhint index.html
+        continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ python plot_axes_scores.py
 ```
 
 This generates `axes_scores_chart.png` in the repository root and shows the chart if possible.
+
+## Continuous Integration
+
+The repository includes a GitHub Actions workflow located at `.github/workflows/lint.yml`.
+It automatically checks syntax of the Python and JavaScript files when a pull request is opened or code is pushed. The steps run `python -m py_compile` on the scripts, `node --check src/app.js` and a basic HTML validation using `npx htmlhint`.


### PR DESCRIPTION
## Summary
- add a GitHub Actions lint workflow for Python, JS and basic HTML validation
- document the workflow in the README

## Testing
- `python -m py_compile plot_axes_scores.py plot_eladeb.py`
- `node --check src/app.js`
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68489f2f6cc08333876be30e12464a9a