### PR TITLE
Improve transition fallback

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -62,7 +62,10 @@ function transition(action) {
     const h = container.offsetHeight;
     container.style.minHeight = `${h}px`;
     container.classList.add('fade-out');
+    let ended = false;
     const onEnd = () => {
+        if (ended) return;
+        ended = true;
         container.removeEventListener('transitionend', onEnd);
         action();
         container.classList.remove('fade-out');
@@ -71,6 +74,9 @@ function transition(action) {
         });
     };
     container.addEventListener('transitionend', onEnd, { once: true });
+    const durStr = getComputedStyle(container).transitionDuration.split(',')[0].trim();
+    const duration = durStr.includes('ms') ? parseFloat(durStr) : parseFloat(durStr) * 1000;
+    setTimeout(onEnd, duration + 50);
 }
 
 function recordState() {


### PR DESCRIPTION
## Summary
- ensure transitions complete even if reduced motion disables animations

## Testing
- `node --check src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6848a7c711588333894c8bdef30728b8