### PR TITLE
Add persistent bottom navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,20 +148,40 @@
             opacity: 1;
             transition: opacity 0.3s ease;
             margin-top: 40px;
-            margin-left: 40px;
         }
         .fade-out { opacity: 0; }
 
-        #back {
-            background: none;
-            border: none;
-            font-size: 36px;
-            color: #2196F3;
-            cursor: pointer;
-            margin: 0;
+
+        #nav-bar {
             position: fixed;
             bottom: 10px;
-            left: 10px;
+            left: 0;
+            right: 0;
+            max-width: 700px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            padding: 10px;
+            background: #fff;
+            border-radius: 10px;
+            box-shadow: 0 -2px 4px rgba(0,0,0,0.2);
+        }
+        #nav-bar button {
+            flex: 1;
+            margin: 0 5px;
+            padding: 10px;
+            font-size: 16px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+        #nav-back {
+            background: #e0e0e0;
+            color: #333;
+        }
+        #nav-next {
+            background: #ff9800;
+            color: #fff;
         }
 
         /* Results styling */
@@ -183,6 +203,10 @@
 <body>
 <h1>ELADEB-R Auto-évaluation</h1>
 <div id="step-container"></div>
+<div id="nav-bar">
+    <button id="nav-back">&larr; Retour</button>
+    <button id="nav-next">&rarr; Passer à l'étape suivante</button>
+</div>
 <script src="src/app.js"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,8 @@ const data = {
 let currentStep = 0;
 let currentDomain = 0;
 let container;
+let navBackBtn;
+let navNextBtn;
 const historyStack = [];
 
 let needColumns;
@@ -198,15 +200,19 @@ function goBack() {
     });
 }
 
+function updateNavBar() {
+    if (navBackBtn) {
+        navBackBtn.disabled = historyStack.length === 0;
+    }
+    if (navNextBtn) {
+        if (currentStep >= 7) navNextBtn.style.display = 'none';
+        else navNextBtn.style.display = '';
+    }
+}
+
 function render() {
     container.innerHTML = '';
-    if (historyStack.length) {
-        const back = document.createElement('button');
-        back.id = 'back';
-        back.innerHTML = '\u2190';
-        back.onclick = goBack;
-        container.appendChild(back);
-    }
+    updateNavBar();
     if (showStepInfo()) return;
     if (currentStep === 0) renderInitialQuestion();
     else if (currentStep === 1) renderDifficultyPresence();
@@ -674,6 +680,18 @@ function renderResults() {
 // Wait for the DOM to be fully loaded before initializing
 document.addEventListener('DOMContentLoaded', () => {
     container = document.getElementById('step-container');
+    navBackBtn = document.getElementById('nav-back');
+    navNextBtn = document.getElementById('nav-next');
+    if (navBackBtn) navBackBtn.onclick = goBack;
+    if (navNextBtn) navNextBtn.onclick = handleNavNext;
     render();
 });
+
+function handleNavNext() {
+    if (currentStep >= 1 && currentStep <= 5) {
+        nextDomain();
+    } else {
+        nextStep();
+    }
+}
 


### PR DESCRIPTION
## Summary
- create a fixed nav bar with back/next buttons
- remove old inline back arrow
- handle nav buttons in JavaScript to move between steps/domains

## Testing
- `node --check src/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6848abb70ea083338044da5d6ee138f7