### PR TITLE
Improve tri summary display

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -167,6 +167,55 @@ function buildSummaryTable() {
     return table;
 }
 
+function buildProblemSummary() {
+    const container = document.createElement('div');
+    container.className = 'summary-container';
+
+    const probCol = document.createElement('div');
+    probCol.className = 'summary-column problem-column';
+    probCol.innerHTML = '<h3>Problème</h3>';
+
+    const okCol = document.createElement('div');
+    okCol.className = 'summary-column ok-column';
+    okCol.innerHTML = '<h3>Pas de problème</h3>';
+
+    let probTotal = 0;
+    let okTotal = 0;
+
+    domains.forEach((d, i) => {
+        const card = document.createElement('div');
+        card.className = 'summary-card';
+        const icon = document.createElement('i');
+        icon.className = `fa ${d.icons[0]}`;
+        card.appendChild(icon);
+        card.appendChild(document.createTextNode(d.label));
+        if (data.difficulties[i].presence) {
+            probTotal++;
+            if (probTotal <= 6) probCol.appendChild(card);
+        } else {
+            okTotal++;
+            if (okTotal <= 6) okCol.appendChild(card);
+        }
+    });
+
+    if (probTotal > 6) {
+        const badge = document.createElement('div');
+        badge.className = 'summary-extra';
+        badge.textContent = `+${probTotal - 6} autres`;
+        probCol.appendChild(badge);
+    }
+    if (okTotal > 6) {
+        const badge = document.createElement('div');
+        badge.className = 'summary-extra';
+        badge.textContent = `+${okTotal - 6} autres`;
+        okCol.appendChild(badge);
+    }
+
+    container.appendChild(probCol);
+    container.appendChild(okCol);
+    return container;
+}
+
 function nextStep() {
     recordState();
     currentStep++;
@@ -527,6 +576,9 @@ function renderResults() {
         div.appendChild(priorityP);
     }
 
+    // Summary of domains classified as problem or not
+    div.appendChild(buildProblemSummary());
+
     const table = document.createElement('table');
     const header = '<tr><th>Domaine</th><th>Intensit\xE9 difficult\xE9</th><th>Urgence besoin</th><th>Origine</th><th>Précisions</th></tr>';
 
@@ -661,5 +713,9 @@ function handleNavNext() {
     } else {
         nextStep();
     }
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { createDomainCard, saveResults, data, buildProblemSummary };
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -129,7 +129,30 @@ th {
     margin-right: 6px;
     color: #2196F3;
     font-size: 20px;
+}
 
+/* Colored columns for tri summary */
+.problem-column {
+    background-color: #ffebee;
+    border: 2px solid #f44336;
+}
+.problem-column h3 { color: #f44336; }
+
+.ok-column {
+    background-color: #e8f5e9;
+    border: 2px solid #4CAF50;
+}
+.ok-column h3 { color: #4CAF50; }
+
+.summary-extra {
+    text-align: center;
+    font-size: 0.9rem;
+    font-weight: bold;
+    margin-top: 4px;
+}
+
+@media (max-width: 600px) {
+    .summary-container { flex-direction: column; }
 }
 
 #step-container {


### PR DESCRIPTION
## Summary
- add two column summary for domains marked as problem or not
- style summary columns with color and responsive layout
- export new helper for tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e1bea45083338aedbdc1f0816586