### PR TITLE
Ajout d’un bouton d’impression avec styles A4

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -650,6 +650,7 @@ function renderResults() {
     div.appendChild(themeCanvas);
 
     const printBtn = document.createElement('button');
+    printBtn.id = 'print-summary';
     printBtn.textContent = 'Imprimer la synthèse';
     printBtn.onclick = () => window.print();
     div.appendChild(printBtn);

--- a/src/style.css
+++ b/src/style.css
@@ -216,3 +216,28 @@ nav.navigation-bar a {
     font-weight: bold;
 }
 
+@page {
+    size: A4 portrait;
+    margin: 15mm;
+}
+
+@media print {
+    body {
+        background: none;
+        -webkit-print-color-adjust: exact;
+    }
+    #nav-bar,
+    #back,
+    #print-summary {
+        display: none !important;
+    }
+    button {
+        box-shadow: none;
+    }
+    .summary-card,
+    table,
+    canvas {
+        page-break-inside: avoid;
+    }
+}
+

--- a/style.css
+++ b/style.css
@@ -175,3 +175,28 @@
             width: 100%;
             box-sizing: border-box;
         }
+
+        @page {
+            size: A4 portrait;
+            margin: 15mm;
+        }
+
+        @media print {
+            body {
+                background: none;
+                -webkit-print-color-adjust: exact;
+            }
+            #nav-bar,
+            #back,
+            #print-summary {
+                display: none !important;
+            }
+            button {
+                box-shadow: none;
+            }
+            .summary-card,
+            table,
+            canvas {
+                page-break-inside: avoid;
+            }
+        }


### PR DESCRIPTION
## Summary
- add print-summary button id for results
- tweak CSS for print: hide navigation elements when printing and set A4 page

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6849e3a8e7608333ac9d166263e1f335