### PR TITLE
Hide back arrow initially

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 <body>
 <h1>ELADEB-R Auto-évaluation</h1>
 <div id="step-container"></div>
-<button id="nav-back">&larr; Étape précédente</button>
+<button id="nav-back" class="hidden">&larr; Étape précédente</button>
 <script src="src/app.js"></script>
 </body>
 </html>

--- a/src/app.js
+++ b/src/app.js
@@ -272,7 +272,9 @@ function goBack() {
 
 function updateNavBar() {
     if (navBackBtn) {
-        navBackBtn.disabled = historyStack.length === 0;
+        const atStart = historyStack.length === 0;
+        navBackBtn.disabled = atStart;
+        navBackBtn.classList.toggle('hidden', atStart);
     }
 }
 


### PR DESCRIPTION
## Summary
- hide back navigation when there is no history
- start back button hidden in markup

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: matplotlib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849f690319c8333934f33d3318d4779