### PR TITLE
Improve summary layouts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -152,17 +152,11 @@ function createNeedMiniCard(domain) {
 
 function updateNeedColumn(col) {
     const cards = Array.from(col.querySelectorAll('.need-mini-card'));
-    let badge = col.querySelector('.extra-indicator');
-    if (!badge) {
-        badge = document.createElement('div');
-        badge.className = 'extra-indicator';
-        col.appendChild(badge);
-    }
-    cards.forEach((c, idx) => {
-        c.style.display = idx < 6 ? 'flex' : 'none';
+    cards.forEach(c => {
+        c.style.display = 'flex';
     });
-    const extra = cards.length - 6;
-    badge.textContent = extra > 0 ? `+${extra} non affichée${extra > 1 ? 's' : ''}` : '';
+    const badge = col.querySelector('.extra-indicator');
+    if (badge) badge.remove();
 }
 
 function buildSummaryTable() {
@@ -206,9 +200,6 @@ function buildProblemSummary() {
     okCol.className = 'summary-column ok-column';
     okCol.innerHTML = '<h3>Pas de problème</h3>';
 
-    let probTotal = 0;
-    let okTotal = 0;
-
     domains.forEach((d, i) => {
         const card = document.createElement('div');
         card.className = 'summary-card';
@@ -217,26 +208,11 @@ function buildProblemSummary() {
         card.appendChild(icon);
         card.appendChild(document.createTextNode(d.label));
         if (data.difficulties[i].presence) {
-            probTotal++;
-            if (probTotal <= 6) probCol.appendChild(card);
+            probCol.appendChild(card);
         } else {
-            okTotal++;
-            if (okTotal <= 6) okCol.appendChild(card);
+            okCol.appendChild(card);
         }
     });
-
-    if (probTotal > 6) {
-        const badge = document.createElement('div');
-        badge.className = 'summary-extra';
-        badge.textContent = `+${probTotal - 6} autres`;
-        probCol.appendChild(badge);
-    }
-    if (okTotal > 6) {
-        const badge = document.createElement('div');
-        badge.className = 'summary-extra';
-        badge.textContent = `+${okTotal - 6} autres`;
-        okCol.appendChild(badge);
-    }
 
     container.appendChild(probCol);
     container.appendChild(okCol);

--- a/src/style.css
+++ b/src/style.css
@@ -150,6 +150,9 @@ th {
     border-radius: 8px;
     padding: 10px;
     min-height: 60px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 .summary-column h3 {
     text-align: center;
@@ -159,15 +162,18 @@ th {
     background: #fff;
     border-radius: 4px;
     padding: 6px;
-    margin-bottom: 8px;
+    margin: 4px;
     box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-    font-size: 14px;
+    font-size: 12px;
+    width: 100px;
+    text-align: center;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
 }
 .summary-card i {
-    margin-right: 6px;
+    margin-bottom: 4px;
     color: #2196F3;
     font-size: 20px;
 }


### PR DESCRIPTION
## Summary
- always display every mini card in needs columns
- remove 6 card limit in problem summary and show all cards
- show summary columns as wrapping flex layouts and style summary cards as small vertical cards

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: matplotlib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849fd7629848333abe58c4eca9ce1fd